### PR TITLE
Add WP Coding Standards as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,8 @@ before_install:
   # Update Composer
   - composer self-update
 
-  # Install phpcs with wp-coding-standards
-  - composer create-project wp-coding-standards/wpcs:0.12.0 --no-dev $HOME/wpcs
-
 script:
-  # Check project with phps
-  - ~/wpcs/vendor/bin/phpcs --extensions=php --standard=./phpcs.xml -n -p .
-
-  # Check that composer is valid and installs correctly
   - composer install -o --prefer-dist --no-interaction
+
+  # Check project with phps
+  - ./vendor/bin/phpcs -n -p .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,15 +14,17 @@ This project comes with a phpcs configuration (`phpcs.xml`) you can use to check
 Run phpcs in the project root directory:
 
 ```
-phpcs --extensions=php --standard=./phpcs.xml -n -p .
+./vendor/bin/phpcs ./
 ```
 
-Before you can run phpcs, you need to install PHP Codesniffer and WordPress coding standards like so:
+You need to install the plugin's development dependencies before you can run the PHPCS checks. A regular
 
 ```
-composer create-project wp-coding-standards/wpcs:dev-master --no-dev $HOME/wpcs
+composer install
 ```
 
-Or read the official installation instructions here:
+should install all the required packages.
+
+You can read the official WPCS installation instructions here:
 
 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards

--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,9 @@
   ],
   "require": {
     "php": ">=5.3.0"
+  },
+  "require-dev": {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+    "wp-coding-standards/wpcs": "0.12.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,10 +4,196 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d2b0c216b20606e43b5538e2c6da8d75",
-    "content-hash": "aa55723b33ede971fc1ba5c2483f0b4c",
+    "hash": "7c5fb105377faa270594b63adec7965d",
+    "content-hash": "f84336481231c05aab1b83368c01cc15",
     "packages": [],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "wimg/php-compatibility": "^8.0"
+            },
+            "suggest": {
+                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "f.nijhof@dealerdirect.nl",
+                    "homepage": "http://workingatdealerdirect.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://workingatdealerdirect.eu",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2017-12-06 16:27:17"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-05-22 02:43:20"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "0.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "reference": "300c15796584d6b63f31841daf674886303af573"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/300c15796584d6b63f31841daf674886303af573",
+                "reference": "300c15796584d6b63f31841daf674886303af573",
+                "shasum": ""
+            },
+            "require": {
+                "squizlabs/php_codesniffer": "^2.9.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "*"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2017-07-20 20:11:03"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,11 +2,15 @@
 <ruleset name="anttiviljami-wordpress">
   <description>For nicer WordPress and PHP development</description>
 
-  <!-- Don't check composer dependencies -->
-  <exclude-pattern>/vendor/</exclude-pattern>
+  <!-- Files and directories to parse -->
+  <file>./classes/</file>
+  <file>./inc/</file>
+  <file>./wp-libre-form.php</file>
 
-  <!-- Exclude language files -->
-  <exclude-pattern>/lang/</exclude-pattern>
+  <!-- Excluded directories and files -->
+  <exclude-pattern>*/vendor/*</exclude-pattern>
+  <exclude-pattern>*/lang/*</exclude-pattern>
+  <exclude-pattern>*/assets/*</exclude-pattern>
 
   <!-- Disallow tabs altogether -->
   <rule ref="Generic.WhiteSpace.DisallowTabIndent.TabsUsed"/>


### PR DESCRIPTION
Previously WPCS had to be installed as some global
thing, now you can just run `composer install` and
use

    $ vendor/bin/phpcs ./

to run PHPCS checks on the codebase.