### PR TITLE
more specific column content hook

### DIFF
--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -32,7 +32,7 @@ class CPT_WPLF_Form {
     // edit.php view
     add_filter( 'post_row_actions', array( $this, 'remove_row_actions' ), 10, 2 );
     add_filter( 'manage_edit-wplf-form_columns', array( $this, 'custom_columns_cpt' ), 100, 1 );
-    add_action( 'manage_posts_custom_column', array( $this, 'custom_columns_display_cpt' ), 10, 2 );
+    add_action( 'manage_wplf-form_posts_custom_column', array( $this, 'custom_columns_display_cpt' ), 10, 2 );
 
     add_filter( 'default_content', array( $this, 'default_content_cpt' ) );
     add_filter( 'user_can_richedit', array( $this, 'disable_tinymce' ) );


### PR DESCRIPTION
WP Libre Form injects its Shortcode column content to other CPTs (i.e. Easy Pricing Tables) if they have a `shortcode` column defined. With the new hook, it is specific to `wplf_form` CPT.

![selection_059](https://user-images.githubusercontent.com/3252474/36446295-8b5ef32a-1689-11e8-9e9e-b2209b6fb64a.png)
