### PR TITLE
Feature/dynamic values

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Use standard HTML5 markup to create fully functional forms for WordPress
 - Full file upload support to Media Library with input type=file
 - Multilingual support with Polylang
 - Predefined static HTML forms via filter hooks
+- Dynamic values, like %USER_EMAIL% for pre-populating form data
 
 ## Why?
 
@@ -173,6 +174,28 @@ Disabling additonal fields validation for all forms:
 
 ```php
 add_filter( 'wplf_disable_validate_additional_fields' , __return_false );
+```
+
+### Filter: wplf_dynamic_values
+
+Add or customize dynamic values available in forms.
+
+#### Example: new value
+
+```php
+add_filter('wplf_dynamic_values', function($values) {
+  $values['SOMETHING'] = [
+    'callback' => function() { return 'something'; },
+    'labels' => [
+      'name' => 'Something',
+      'description' => 'Something really useful.'
+    ],
+  ];
+
+  return $values;
+});
+
+// <input type="text" placeholder="%SOMETHING%" name="something">
 ```
 
 ## Javascript API

--- a/assets/scripts/wplf-admin-form.js
+++ b/assets/scripts/wplf-admin-form.js
@@ -82,6 +82,26 @@ $(document).ready(function() {
   }
 
   $('input[name="wplf_version_update_toggle"]').change(toggleVersionUpdate);
+
+  function showDynamicValueInfo(e) {
+    var target = e.target;
+    var value = target.value;
+    var help = $('.wplf-dynamic-values-help');
+    var desc = help.find('.description');
+    var usage = help.find('.usage span');
+
+    if (value) {
+      var option = target.querySelector('option[value="' + value + '"]');
+      var labels = JSON.parse(option.getAttribute('data-labels'));
+      desc.html(labels.description);
+      usage.text('%' + value + '%');
+      help.show();
+    } else {
+      help.hide();
+    }
+  }
+
+  $('select[name="wplf-dynamic-values"]').change(showDynamicValueInfo);
 });
 
 })(jQuery);

--- a/assets/scripts/wplf-form.js
+++ b/assets/scripts/wplf-form.js
@@ -20,10 +20,11 @@ window.wplf = {
       error.parentNode.removeChild(error);
     });
 
-    fetch(ajax_object.ajax_url  + '?action=wplf_submit', {
+    fetch(ajax_object.ajax_url, {
       method: "POST",
       credentials: ajax_object.ajax_credentials || 'same-origin',
-      body: data
+      body: data,
+      headers: ajax_object.request_headers || {},
     }).then(function(response) {
       return response.text();
     }).then(function(response) {

--- a/assets/styles/wplf-admin-form.css
+++ b/assets/styles/wplf-admin-form.css
@@ -9,3 +9,12 @@
     color: #666;
     font-style: italic;
 }
+
+.wplf-dynamic-values-help {
+  display: none;
+  margin-top: 1rem;
+}
+
+.wplf-dynamic-values-help .description {
+  margin-bottom: 2rem;
+}

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -408,18 +408,26 @@ class CPT_WPLF_Form {
   public function metabox_dynamic_values( $post ) {
     unset( $post ); ?>
     <select name="wplf-dynamic-values">
-      <option><?php esc_html_e( 'Choose a dynamic value', 'wp-libre-form' ); ?></option>
+      <option default value=""><?php esc_html_e( 'Choose a dynamic value', 'wp-libre-form' ); ?></option>
 
       <?php foreach ( ( WPLF_Dynamic_Values::get_available() ) as $k => $v ) {
         $key = sanitize_text_field( $k );
-        $labels = wp_json_encode( $v['labels'] );
+        $labels = $v['labels'];
+        $stringified = wp_json_encode( $labels );
 
         // WPCS won't STFU. It's wrong. Again.
-        echo "<option value='$key' data-labels='$labels'>$key</option>"; // @codingStandardsIgnoreLine
+        echo "<option value='$key' data-labels='$stringified'>$labels[name]</option>"; // @codingStandardsIgnoreLine
       } ?>
     </select>
 
-    <div class="wplf-dynamic-values-description"></div>
+    <!-- Shown with JS. -->
+    <div class="wplf-dynamic-values-help">
+      <div class="description"></div>
+      <div class="usage">
+        <strong><?php esc_html_e( 'Usage', 'wp-libre-form' ); ?>:&nbsp;</strong>
+        <span></span>
+      </div>
+    </div>
 <?php
   }
 

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -849,7 +849,7 @@ class CPT_WPLF_Form {
       $content = apply_filters( "wplf_{$form->ID}_form", $content );
 
       // run default filters after. The user probably wants to filter original content, not modified by WP
-      $content = apply_filters( 'wplf_form', $content );
+      $content = apply_filters( 'wplf_form', $content, $id, $xclass, $attributes );
 
       ob_start();
 ?>

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -408,13 +408,18 @@ class CPT_WPLF_Form {
   public function metabox_dynamic_values( $post ) {
     unset( $post ); ?>
     <select name="wplf-dynamic-values">
-    <?php foreach ( ( WPLF_Dynamic_Values::get_available() ) as $k => $v ) {
-      $key = sanitize_text_field( $k );
+      <option><?php esc_html_e( 'Choose a dynamic value', 'wp-libre-form' ); ?></option>
 
-      // WPCS won't STFU. It's wrong. Again.
-      echo "<option value='$key'>$key</option>"; // @codingStandardsIgnoreLine
-    } ?>
+      <?php foreach ( ( WPLF_Dynamic_Values::get_available() ) as $k => $v ) {
+        $key = sanitize_text_field( $k );
+        $labels = wp_json_encode( $v['labels'] );
+
+        // WPCS won't STFU. It's wrong. Again.
+        echo "<option value='$key' data-labels='$labels'>$key</option>"; // @codingStandardsIgnoreLine
+      } ?>
     </select>
+
+    <div class="wplf-dynamic-values-description"></div>
 <?php
   }
 

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -334,6 +334,16 @@ class CPT_WPLF_Form {
       'high'
     );
 
+    // Dynamic values
+    add_meta_box(
+      'wplf-shortcode',
+      __( 'Dynamic values', 'wp-libre-form' ),
+      array( $this, 'metabox_dynamic_values' ),
+      'wplf-form',
+      'normal',
+      'high'
+    );
+
     // Messages meta box
     add_meta_box(
       'wplf-messages',
@@ -389,6 +399,22 @@ class CPT_WPLF_Form {
   public function metabox_shortcode( $post ) {
 ?>
 <p><input type="text" class="code" value='[libre-form id="<?php echo esc_attr( $post->ID ); ?>"]' readonly></p>
+<?php
+  }
+
+  /**
+   * Meta box callback for dynamic values meta box
+   */
+  public function metabox_dynamic_values( $post ) {
+    unset( $post ); ?>
+    <select name="wplf-dynamic-values">
+    <?php foreach ( ( WPLF_Dynamic_Values::get_available() ) as $k => $v ) {
+      $key = sanitize_text_field( $k );
+
+      // WPCS won't STFU. It's wrong. Again.
+      echo "<option value='$key'>$key</option>"; // @codingStandardsIgnoreLine
+    } ?>
+    </select>
 <?php
   }
 

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -924,10 +924,13 @@ class CPT_WPLF_Form {
       true
     );
 
+    $admin_url = admin_url( 'admin-ajax.php' );
+
     // add dynamic variables to the script's scope
     wp_localize_script('wplf-form-js', 'ajax_object', apply_filters( 'wplf_ajax_object', array(
-      'ajax_url' => admin_url( 'admin-ajax.php' ),
+      'ajax_url' => apply_filters( 'wplf_ajax_endpoint', "$admin_url?action=wplf_submit" ),
       'ajax_credentials' => apply_filters( 'wplf_ajax_fetch_credentials_mode', 'same-origin' ),
+      'request_headers' => apply_filters( 'wplf_ajax_request_headers', '?action=wplf_submit' ),
       'wplf_assets_dir' => plugin_dir_url( realpath( __DIR__ . '/../wp-libre-form.php' ) ) . 'assets',
     ) ) );
   }

--- a/classes/class-wplf-dynamic-values.php
+++ b/classes/class-wplf-dynamic-values.php
@@ -3,7 +3,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
   class WPLF_Dynamic_Values {
 
     public static $instance;
-    protected $regular_expression = "/%[^{}\n]+%/";
+    protected $regular_expression = "/%[^%%\n]+%/";
     protected $strings = array();
 
     public static function init() {

--- a/classes/class-wplf-dynamic-values.php
+++ b/classes/class-wplf-dynamic-values.php
@@ -98,8 +98,8 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
     public function populate_value( $string, $data = [] ) {
       $available = self::get_available();
 
-      if ( ! empty( $available[ $string ] ) && is_callable( $available[ $string ] ) ) {
-        return $available[ $string ]($data);
+      if ( ! empty( $available[ $string ] ) && is_callable( $available[ $string ]['callback'] ) ) {
+        return $available[ $string ]['callback']($data);
       }
     }
   }

--- a/classes/class-wplf-dynamic-values.php
+++ b/classes/class-wplf-dynamic-values.php
@@ -39,9 +39,28 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
     }
 
     public static function get_available() {
-      return apply_filters( 'wplf_dynamic_values', array(
-        'USER_ID' => 'get_current_user_id',
-        'USER_EMAIL' => function () {
+      $register = function( $value, $callback, $labels = array() ) use ( &$available ) {
+        if ( ! is_callable( $callback ) ) {
+          throw new Exception( '$callback is not callable' );
+        }
+
+        $available[ $value ] = [
+          'callback' => $callback,
+          'labels' => array_merge([
+            'name' => $value,
+            'description' => esc_html__( 'No description provided', 'wp-libre-form' ),
+          ], $labels),
+        ];
+
+        return $available;
+      };
+
+      return apply_filters( 'wplf_dynamic_values', array_merge(
+        $register('USER_ID', 'get_current_user_id', [
+          'name' => esc_html__( 'User ID', 'wp-libre-form' ),
+          'description' => esc_html__( 'Get current user ID. Prints 0 if user isn\'t logged in.', 'wp-libre-form' ),
+        ]),
+        $register('USER_EMAIL', function () {
           $user = wp_get_current_user();
 
           if ( $user->ID === 0 ) {
@@ -49,8 +68,11 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
           }
 
           return $user->user_email;
-        },
-        'USER_NAME' => function () {
+        }, [
+          'name' => esc_html__( 'User email', 'wp-libre-form' ),
+          'description' => esc_html__( 'Get user email, if it exists.', 'wp-libre-form' ),
+        ]),
+        $register('USER_NAME', function () {
           $user = wp_get_current_user();
 
           if ( $user->ID === 0 ) {
@@ -58,10 +80,18 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
           }
 
           return "{$user->first_name} {$user->last_name}";
-        },
-        'TIMESTAMP' => function () {
+        }, [
+          'name' => esc_html__( 'User name', 'wp-libre-form' ),
+          'description' => esc_html__( 'Get user name, if it exists.', 'wp-libre-form' ),
+        ]),
+        $register('TIMESTAMP', function () {
           return date( 'U' );
-        },
+        }, [
+          'name' => esc_html__( 'Timestamp', 'wp-libre-form' ),
+          'description' => esc_html__(
+            'Get UNIX epoch at the time of form render. Can be used to determine how long did it take for the user to fill the form.'
+          ),
+        ])
       ) );
     }
 

--- a/classes/class-wplf-dynamic-values.php
+++ b/classes/class-wplf-dynamic-values.php
@@ -1,0 +1,79 @@
+<?php
+if ( ! class_exists( 'WPLF_Polylang' ) ) {
+  class WPLF_Dynamic_Values {
+
+    public static $instance;
+    protected $regular_expression = "/%[^{}\n]+%/";
+    protected $strings = array();
+
+    public static function init() {
+      if ( is_null( self::$instance ) ) {
+        self::$instance = new WPLF_Dynamic_Values();
+      }
+      return self::$instance;
+    }
+
+    /**
+     * Hook our actions, filters and such
+     */
+    public function __construct() {
+      add_filter( 'wplf_form', array( $this, 'render_form' ), 10, 4 );
+    }
+
+    public function render_form( $content, $id, $xclass, $attributes ) {
+      // Get all strings inside % placeholders
+      preg_match_all( $this->regular_expression, $content, $matches );
+      foreach ( $matches[0] as $match ) {
+        // match contains the braces, get rid of them.
+        $string = trim( str_replace( array( '%' ), array( '' ), $match ) );
+        $content = str_replace(
+          $match,
+          $this->populate_value(
+            $string,
+            compact( 'content', 'id', 'xclass', 'attributes' )
+          ),
+          $content
+        );
+      }
+
+      return $content;
+    }
+
+    public function get_available() {
+      return apply_filters( 'wplf_dynamic_values', array (
+        'USER_ID' => 'get_current_user_id',
+        'USER_EMAIL' => function () {
+          $user = wp_get_current_user();
+
+          if ( $user->ID === 0 ) {
+            return false;
+          }
+
+          return $user->user_email;
+        },
+        'USER_NAME' => function () {
+          error_log("getting name");
+          $user = wp_get_current_user();
+          error_log(print_r($user, true));
+
+          if ( $user->ID === 0 ) {
+            return false;
+          }
+
+          return "{$user->first_name} {$user->last_name}";
+        },
+        'DATE' => function () { return date('U'); },
+      ) );
+    }
+
+    public function populate_value ( $string, $data = [] ) {
+      $available = $this->get_available();
+
+      if (!empty($available[$string]) && is_callable($available[$string])) {
+        return $available[$string]($data);
+      } else {
+        error_log("No callable found for $string");
+      }
+    }
+  }
+}

--- a/classes/class-wplf-dynamic-values.php
+++ b/classes/class-wplf-dynamic-values.php
@@ -38,7 +38,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
       return $content;
     }
 
-    public function get_available() {
+    public static function get_available() {
       return apply_filters( 'wplf_dynamic_values', array(
         'USER_ID' => 'get_current_user_id',
         'USER_EMAIL' => function () {
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
     }
 
     public function populate_value( $string, $data = [] ) {
-      $available = $this->get_available();
+      $available = self::get_available();
 
       if ( ! empty( $available[ $string ] ) && is_callable( $available[ $string ] ) ) {
         return $available[ $string ]($data);

--- a/classes/class-wplf-dynamic-values.php
+++ b/classes/class-wplf-dynamic-values.php
@@ -4,7 +4,6 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
 
     public static $instance;
     protected $regular_expression = "/%[^%%\n]+%/";
-    protected $strings = array();
 
     public static function init() {
       if ( is_null( self::$instance ) ) {
@@ -24,7 +23,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
       // Get all strings inside % placeholders
       preg_match_all( $this->regular_expression, $content, $matches );
       foreach ( $matches[0] as $match ) {
-        // match contains the braces, get rid of them.
+        // match contains the % chars, get rid of them.
         $string = trim( str_replace( array( '%' ), array( '' ), $match ) );
         $content = str_replace(
           $match,
@@ -40,7 +39,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
     }
 
     public function get_available() {
-      return apply_filters( 'wplf_dynamic_values', array (
+      return apply_filters( 'wplf_dynamic_values', array(
         'USER_ID' => 'get_current_user_id',
         'USER_EMAIL' => function () {
           $user = wp_get_current_user();
@@ -52,9 +51,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
           return $user->user_email;
         },
         'USER_NAME' => function () {
-          error_log("getting name");
           $user = wp_get_current_user();
-          error_log(print_r($user, true));
 
           if ( $user->ID === 0 ) {
             return false;
@@ -62,17 +59,17 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
 
           return "{$user->first_name} {$user->last_name}";
         },
-        'DATE' => function () { return date('U'); },
+        'TIMESTAMP' => function () {
+          return date( 'U' );
+        },
       ) );
     }
 
-    public function populate_value ( $string, $data = [] ) {
+    public function populate_value( $string, $data = [] ) {
       $available = $this->get_available();
 
-      if (!empty($available[$string]) && is_callable($available[$string])) {
-        return $available[$string]($data);
-      } else {
-        error_log("No callable found for $string");
+      if ( ! empty( $available[ $string ] ) && is_callable( $available[ $string ] ) ) {
+        return $available[ $string ]($data);
       }
     }
   }

--- a/wp-libre-form.php
+++ b/wp-libre-form.php
@@ -63,6 +63,8 @@ class WP_Libre_Form {
 
     add_action( 'plugins_loaded', array( $this, 'load_our_textdomain' ) );
 
+    add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+
     // flush rewrites on activation since we have slugs for our cpts
     register_activation_hook( __FILE__, array( 'WP_Libre_Form', 'flush_rewrites' ) );
     register_deactivation_hook( __FILE__, 'flush_rewrite_rules' );
@@ -85,6 +87,14 @@ class WP_Libre_Form {
     if ( ! $loaded ) {
       $loaded = load_muplugin_textdomain( 'wp-libre-form', dirname( plugin_basename( __FILE__ ) ) . '/lang/' );
     }
+  }
+
+  public function register_rest_routes() {
+    register_rest_route( 'wplf/v1', 'submit', [
+      'methods' => 'POST',
+      'callback' => 'wplf_ajax_submit_handler', // admin-ajax handler, works but...
+      // The REST API handbook discourages from using $_POST, and instead use $request->get_params()
+    ]);
   }
 
   /**

--- a/wp-libre-form.php
+++ b/wp-libre-form.php
@@ -47,6 +47,7 @@ class WP_Libre_Form {
   private function __construct() {
     require_once 'classes/class-cpt-wplf-form.php';
     require_once 'classes/class-cpt-wplf-submission.php';
+    require_once 'classes/class-wplf-dynamic-values.php';
     require_once 'inc/wplf-ajax.php';
 
     // default functionality
@@ -56,6 +57,7 @@ class WP_Libre_Form {
     // init our plugin classes
     CPT_WPLF_Form::init();
     CPT_WPLF_Submission::init();
+    WPLF_Dynamic_Values::init();
 
     add_action( 'after_setup_theme', array( $this, 'init_polylang_support' ) );
 


### PR DESCRIPTION
I need to prefill user email in this case I'm working on.  

So: 
```
<input type="text" name="email" placeholder="someone@somewhere.com" value="%USER_EMAIL%">
```

I'm  using the REST API  to get the forms, which means I'm not logged into WP with a cookie. I need to send an authorization header in order to get a response with correct pre-filled values, which is why I've edited the client side JS a bit. 

And in order to have login state when the user submits the form, I'm going to have to route the submission through the REST API, so I created a REST route for it. 

The thing is, I used wplf_ajax_submit_handler directly, which works. But  I'm fairly certain WordPress documentation tells you not to use $_POST directly in REST callbacks, but to use $request->get_params() instead. Which could be problematic. Maybe. 

We probably should migrate to using the REST API anyway, but that's a different PR. Do you think I should remove the endpoint (and define it elsewhere, in a different plugin, since I need it), or could we merge it as an undocumented feature?

