### PR TITLE
Form query optimizations

### DIFF
--- a/classes/class-cpt-wplf-submission.php
+++ b/classes/class-cpt-wplf-submission.php
@@ -130,10 +130,14 @@ class CPT_WPLF_Submission {
     if ( $transient ) {
       $forms = $transient;
     } else {
-      $forms = get_posts( array(
+      $query = new WP_Query( array(
         'post_per_page' => '-1',
         'post_type' => 'wplf-form',
+        'no_found_rows' => true,
+        'update_post_meta_cache' => false,
+        'update_post_term_cache' => false,
       ) );
+      $forms = $query->get_posts();
 
       set_transient( 'wplf-form-filter', $forms, 15 * MINUTE_IN_SECONDS );
     }


### PR DESCRIPTION
## Reason

My customer uses **polylang plugin** to create a form for each language (I did not know the native integration that wplf has). So some forms, some forms did not appear in the filter dropdown. But with `WP_Query` it appears (I don't know why).

## Optimizations

A new `WP_Query` object runs five queries by default, including calculating pagination and priming the term and meta caches. Each of the following arguments will remove a query:

- `'no_found_rows' => true`: useful when pagination is not needed.
- `'update_post_meta_cache' => false`: useful when post meta will not be utilized.
- `'update_post_term_cache' => false`: useful when taxonomy terms will not be utilized.

Note: `get_posts()` actually calls `WP_Query`, but calling `get_posts()` directly bypasses a number of filters by default. Not sure whether you need these things or not? You probably don’t.

Based on: https://10up.github.io/Engineering-Best-Practices/php/#performance