### PR TITLE
Hotfix for the array to string conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2019-10-11
+- Hotfix for wp_mail() $headers initial value. Fixes array to string conversion.
+
 # 1.5
 - Better client side JavaScript bundle, polyfills are now only loaded when required
 - Much more control for emails, straight on the invidual form level

--- a/inc/wplf-form-actions.php
+++ b/inc/wplf-form-actions.php
@@ -44,7 +44,7 @@ function wplf_send_email_copy( $return, $submission_id = null ) {
     $content .= wplf_email_copy_make_fields_key_value_list( $fields, $form->ID, $form->post_name );
 
     // default pre-filtered values for email headers and attachments
-    $headers = array();
+    $headers     = '';
     $attachments = array();
 
     if ( isset( $form_meta['_wplf_email_copy_from'][0] ) ) {


### PR DESCRIPTION
Hello, I found a bug. 🐛 

On the line 53. Code fails because of array to string conversion.
https://github.com/Liblastic/wp-libre-form/blob/master/inc/wplf-form-actions.php#L53

This should fix the problem.