### PR TITLE
Lighter way of counting submissions on plugin dashboard

### DIFF
--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -316,9 +316,9 @@ class CPT_WPLF_Form {
     }
     if ( 'submissions' === $column ) {
       // count number of submissions
-			global $wpdb;
-      $get_submissions_count = $wpdb->get_row( 'select count(*) as amount from '.$wpdb->postmeta.' where meta_key = "_form_id" and meta_value = "'.$post_id.'"' );
-			$submissions = $get_submissions_count->amount;
+      global $wpdb;
+      $query = $wpdb->get_row( 'select count(*) as amount from ' . $wpdb->postmeta . ' where meta_key = "_form_id" and meta_value = "' . absint($post_id) . '"' );
+      $submissions = $query->amount;
 ?>
   <a href="<?php echo esc_url_raw( admin_url( 'edit.php?post_type=wplf-submission&form=' . $post_id ) ); ?>">
     <?php echo $submissions; ?>

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -317,11 +317,11 @@ class CPT_WPLF_Form {
     if ( 'submissions' === $column ) {
       // count number of submissions
       global $wpdb;
-      $query = $wpdb->get_row( 'select count(*) as amount from ' . $wpdb->postmeta . ' where meta_key = "_form_id" and meta_value = "' . absint($post_id) . '"' );
+      $query = $wpdb->get_row( 'select count(*) as amount from ' . $wpdb->postmeta . ' where meta_key = "_form_id" and meta_value = "' . absint( $post_id ) . '"' );
       $submissions = $query->amount;
 ?>
   <a href="<?php echo esc_url_raw( admin_url( 'edit.php?post_type=wplf-submission&form=' . $post_id ) ); ?>">
-    <?php echo $submissions; ?>
+    <?php echo esc_html($submissions); ?>
   </a>
 <?php
     }

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -321,7 +321,7 @@ class CPT_WPLF_Form {
       $submissions = $query->amount;
 ?>
   <a href="<?php echo esc_url_raw( admin_url( 'edit.php?post_type=wplf-submission&form=' . $post_id ) ); ?>">
-    <?php echo esc_html($submissions); ?>
+    <?php echo esc_html( $submissions ); ?>
   </a>
 <?php
     }

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -316,16 +316,12 @@ class CPT_WPLF_Form {
     }
     if ( 'submissions' === $column ) {
       // count number of submissions
-      $submissions = get_posts( array(
-        'post_type' => 'wplf-submission',
-        'posts_per_page' => -1,
-        'meta_key' => '_form_id',
-        'meta_value' => $post_id,
-        'suppress_filters' => false,
-      ) );
+			global $wpdb;
+      $get_submissions_count = $wpdb->get_row( 'select count(*) as amount from '.$wpdb->postmeta.' where meta_key = "_form_id" and meta_value = "'.$post_id.'"' );
+			$submissions = $get_submissions_count->amount;
 ?>
   <a href="<?php echo esc_url_raw( admin_url( 'edit.php?post_type=wplf-submission&form=' . $post_id ) ); ?>">
-    <?php echo count( $submissions ); ?>
+    <?php echo $submissions; ?>
   </a>
 <?php
     }


### PR DESCRIPTION
Previously the dashboard fetched all posts for every form and only after that the submissions were counted. This does a lighter query that only returns the amount of submissions.